### PR TITLE
Oled Timeout Update for KidBrazil Keymap

### DIFF
--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -73,15 +73,9 @@ void persistent_default_layer_set(uint16_t default_layer) {
 bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
-
-        #ifdef OLED_DRIVER_ENABLE
-            // Reset Timer to restore OLED
-            oled_timer = timer_read32();
-        #endif
-
+        oled_timer = timer_read32();
         // Restore LEDs if they are enabled in eeprom
         rgb_matrix_enable_noeeprom();
-
     }
     return true;
 }

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -1,8 +1,6 @@
 #include QMK_KEYBOARD_H
 
 // [Init Variables] ----------------------------------------------------------//
-//Following line allows macro to read current RGB settings
-extern rgblight_config_t rgblight_config;
 extern uint8_t is_master;
 // Oled timer similar to Drashna's
 static uint32_t oled_timer = 0;
@@ -64,17 +62,17 @@ void persistent_default_layer_set(uint16_t default_layer) {
 
 // [Process User Input] ------------------------------------------------------//
 bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+    // Get current EEPROM RGB settings...
+    rgblight_config_t rgblight_config;
+    rgblight_config.raw = eeconfig_read_rgblight();
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
-        // Get current EEPROM RGB settings...
-        rgblight_config_t rgblight_config;
-        rgblight_config.raw = eeconfig_read_rgblight();
 
         #ifdef OLED_DRIVER_ENABLE
             // Reset Timer to restore OLED
             oled_timer = timer_read32();
         #endif
-        
+
         // Restore LEDs if they are enabled in eeprom
         if (rgblight_config.enable) {
             rgblight_enable_noeeprom()
@@ -204,7 +202,7 @@ void oled_task_user(void) {
       // Drashna style timeout for LED and OLED
       if (timer_elapsed32(oled_timer) > 30000) {
           oled_off();
-          rgblight_disable_noeeprom()
+          rgblight_disable_noeeprom();
           return;
       }
       else {

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -201,7 +201,10 @@ void render_slave_oled(void) {
 // {OLED Task} -----------------------------------------------//
 void oled_task_user(void) {
       // Drashna style timeout for LED and OLED
-      if (timer_elapsed32(oled_timer) > 30000) {
+      if (timer_elapsed32(oled_timer) > 15000) {
+          render_logo();
+      }
+      else if (timer_elapsed32(oled_timer) > 30000) {
           oled_off();
           rgb_matrix_disable_noeeprom();
           return;

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -201,10 +201,7 @@ void render_slave_oled(void) {
 // {OLED Task} -----------------------------------------------//
 void oled_task_user(void) {
       // Drashna style timeout for LED and OLED
-      if (timer_elapsed32(oled_timer) > 15000) {
-          render_logo();
-      }
-      else if (timer_elapsed32(oled_timer) > 30000) {
+      if (timer_elapsed32(oled_timer) > 30000) {
           oled_off();
           rgb_matrix_disable_noeeprom();
           return;

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -70,7 +70,7 @@ void persistent_default_layer_set(uint16_t default_layer) {
 // }
 
 // [Process User Input] ------------------------------------------------------//
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
         oled_timer = timer_read32();

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -62,12 +62,12 @@ void persistent_default_layer_set(uint16_t default_layer) {
     default_layer_set(default_layer);
 }
 
-void matrix_scan_user(void) {
-    rgblight_config_t rgblight_config;
-    rgblight_config.raw = eeconfig_read_rgblight();
-    // Save LED State
-    eeprom_oled_enabled = rgblight_config.enable;
-}
+// void matrix_scan_user(void) {
+//     rgblight_config_t rgblight_config;
+//     rgblight_config.raw = eeconfig_read_rgblight();
+//     // Save LED State
+//     eeprom_oled_enabled = rgblight_config.enable;
+// }
 
 // [Process User Input] ------------------------------------------------------//
 bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
@@ -80,9 +80,8 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
         #endif
 
         // Restore LEDs if they are enabled in eeprom
-        if (eeprom_oled_enabled) {
-            rgblight_enable_noeeprom();
-        }
+        rgb_matrix_enable_noeeprom();
+
     }
     return true;
 }
@@ -208,7 +207,7 @@ void oled_task_user(void) {
       // Drashna style timeout for LED and OLED
       if (timer_elapsed32(oled_timer) > 30000) {
           oled_off();
-          rgblight_disable_noeeprom();
+          rgb_matrix_disable_noeeprom();
           return;
       }
       else {

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -73,7 +73,9 @@ void persistent_default_layer_set(uint16_t default_layer) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
-        oled_timer = timer_read32();
+        #ifdef OLED_DRIVER_ENABLE
+            oled_timer = timer_read32();
+        #endif
         // Restore LEDs if they are enabled in eeprom
         rgb_matrix_enable_noeeprom();
     }

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -4,6 +4,8 @@
 extern uint8_t is_master;
 // Oled timer similar to Drashna's
 static uint32_t oled_timer = 0;
+// Boolean to store
+bool eeprom_oled_enabled = false;
 
 // [CRKBD layers Init] -------------------------------------------------------//
 enum crkbd_layers {
@@ -60,11 +62,15 @@ void persistent_default_layer_set(uint16_t default_layer) {
     default_layer_set(default_layer);
 }
 
-// [Process User Input] ------------------------------------------------------//
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-    // Get current EEPROM RGB settings...
+void matrix_scan_user(void) {
     rgblight_config_t rgblight_config;
     rgblight_config.raw = eeconfig_read_rgblight();
+    // Save LED State
+    eeprom_oled_enabled = rgblight_config.enable;
+}
+
+// [Process User Input] ------------------------------------------------------//
+bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
 
@@ -74,7 +80,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
         #endif
 
         // Restore LEDs if they are enabled in eeprom
-        if (rgblight_config.enable) {
+        if (eeprom_oled_enabled) {
             rgblight_enable_noeeprom()
         }
     }

--- a/keyboards/crkbd/keymaps/kidbrazil/keymap.c
+++ b/keyboards/crkbd/keymaps/kidbrazil/keymap.c
@@ -4,6 +4,8 @@
 extern uint8_t is_master;
 // Oled timer similar to Drashna's
 static uint32_t oled_timer = 0;
+// Boolean to store
+bool eeprom_oled_enabled = false;
 
 // [CRKBD layers Init] -------------------------------------------------------//
 enum crkbd_layers {
@@ -60,11 +62,15 @@ void persistent_default_layer_set(uint16_t default_layer) {
     default_layer_set(default_layer);
 }
 
-// [Process User Input] ------------------------------------------------------//
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-    // Get current EEPROM RGB settings...
+void matrix_scan_user(void) {
     rgblight_config_t rgblight_config;
     rgblight_config.raw = eeconfig_read_rgblight();
+    // Save LED State
+    eeprom_oled_enabled = rgblight_config.enable;
+}
+
+// [Process User Input] ------------------------------------------------------//
+bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
     // Use process_record_keymap to reset timer on keypress
     if (record->event.pressed) {
 
@@ -74,8 +80,8 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
         #endif
 
         // Restore LEDs if they are enabled in eeprom
-        if (rgblight_config.enable) {
-            rgblight_enable_noeeprom()
+        if (eeprom_oled_enabled) {
+            rgblight_enable_noeeprom();
         }
     }
     return true;

--- a/keyboards/crkbd/keymaps/kidbrazil/rules.mk
+++ b/keyboards/crkbd/keymaps/kidbrazil/rules.mk
@@ -8,8 +8,7 @@ RGB_MATRIX_ENABLE = WS2812
 OLED_DRIVER_ENABLE = yes
 
 # If you want to change the display of OLED, you need to change here
-SRC +=  ./keyboards/crkbd/keymaps/kidbrazil/layer_state_reader.c \
-        ./keyboards/crkbd/keymaps/kidbrazil/logo_reader.c \
+SRC +=  ./keyboards/crkbd/keymaps/kidbrazil/logo_reader.c \
         #./lib/rgb_state_reader.c \
         #./lib/logo_reader.c \
         #./lib/keylogger.c \


### PR DESCRIPTION
Minor update to the CRKBD Keymap. Introduces a simple timer to switch off RGB Matrix and OLED screen based on timeout.


